### PR TITLE
Add human-preference learning system for coat of arms design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /node_modules/
 /public/build/
+/public/sw.js
+/public/sw.js.map
 .DS_Store
+preference/preference_data.json
+preference/__pycache__/
+preference/.venv/
+core.*
+*.pyc

--- a/preference/README.md
+++ b/preference/README.md
@@ -7,7 +7,7 @@ A human-preference model that helps you pick your ideal coat of arms. The system
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
 │  Armoria Svelte  │────▶│  Preference API   │────▶│  Reward Model   │
-│  Frontend        │     │  (FastAPI, 8787)  │     │  (GBC + feature │
+│  Frontend        │     │  (FastAPI, 8080)  │     │  (GBC + feature │
 │  (Svelte 3)      │◀────│                   │◀────│   extraction)   │
 └─────────────────┘     └──────────────────┘     └─────────────────┘
 ```
@@ -95,6 +95,13 @@ Click the **"Preference Mode"** button in the top-right corner of the Armoria he
 - You can also click **"Train Model"** at any time from the toolbar
 - Stats (preference count, model accuracy, training samples) are shown in the dashboard
 
+### Favorites
+
+- Click the **"Favorites"** tab to review all designs you liked
+- **Grid Selections**: Coats of arms you selected as favourites during grid rounds
+- **Pairwise Winners**: Coats of arms you chose in head-to-head comparisons
+- Click any coat of arms to copy its JSON to clipboard
+
 ## API Endpoints
 
 | Method | Endpoint | Description |
@@ -106,6 +113,7 @@ Click the **"Preference Mode"** button in the top-right corner of the Armoria he
 | POST | `/api/suggest-pair` | Get the most uncertain pair (active learning) |
 | GET | `/api/stats` | Get preference and model statistics |
 | POST | `/api/reset` | Clear all preferences and reset the model |
+| GET | `/api/favorites` | Get liked COAs grouped by source (grid selections and pairwise winners) |
 
 ## Feature Extraction
 

--- a/preference/README.md
+++ b/preference/README.md
@@ -1,0 +1,123 @@
+# Armoria Preference Learning System
+
+A human-preference model that helps you pick your ideal coat of arms. The system uses a three-phase workflow: grid selection, pairwise comparison with active learning, and model-guided generation via rejection sampling.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Armoria Svelte  │────▶│  Preference API   │────▶│  Reward Model   │
+│  Frontend        │     │  (FastAPI, 8787)  │     │  (GBC + feature │
+│  (Svelte 3)      │◀────│                   │◀────│   extraction)   │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+```
+
+- **Frontend**: Svelte 3 components integrated into Armoria's existing UI
+- **Backend**: FastAPI server handling preference storage, model training, scoring, and active learning
+- **Model**: Gradient Boosted Classifier trained on pairwise feature differences
+- **Storage**: JSON file (`preference_data.json`) for easy inspection and portability
+
+## Setup
+
+### 1. Install Python dependencies
+
+```bash
+cd armoria/preference
+pip install -r requirements.txt
+```
+
+### 2. Start the backend
+
+```bash
+cd armoria
+python -m uvicorn preference.server:app --reload --port 8787 --host 0.0.0.0
+```
+
+#### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PREFERENCE_CORS_ORIGINS` | `http://localhost:5000` | Comma-separated list of allowed CORS origins |
+| `PREFERENCE_HOST` | `0.0.0.0` | Server bind host |
+| `PREFERENCE_PORT` | `8787` | Server bind port |
+
+Example with custom CORS:
+
+```bash
+PREFERENCE_CORS_ORIGINS='http://localhost:5000,http://localhost:8080' \
+  python -m uvicorn preference.server:app --reload --port 8787 --host 0.0.0.0
+```
+
+### 3. Start the frontend
+
+```bash
+cd armoria
+npm install
+npm run dev
+```
+
+The frontend runs on `http://localhost:5000` by default (or pass `PORT=8080 npm run dev`).
+
+### 4. Enter Preference Mode
+
+Click the **"Preference Mode"** button in the top-right corner of the Armoria header.
+
+## Three-Phase Workflow
+
+### Phase 1: Grid Selection
+
+- A grid of 20 randomly generated coats of arms is displayed
+- Click on any coat of arms to select it as a favourite (green border)
+- Click **"Submit & Next Round"** to record your preferences and get a new batch
+- Repeat for several rounds (recommended: 5-10 rounds, ~100-200 preferences)
+- Click **"Finish Phase 1"** to auto-train the model and proceed
+
+### Phase 2: Pairwise Comparison
+
+- Two coats of arms are shown side by side
+- Click the one you prefer
+- If the model is trained, active learning selects the most informative pairs
+- Otherwise, pairs are random
+- Repeat for 50-200 comparisons to refine the model
+- Click **"Finish Phase 2"** to auto-retrain and proceed
+
+### Phase 3: Guided Generation
+
+- Click **"Generate"** to create 200 random coats of arms, score them with the model, and display the top 20
+- Each coat of arms shows its preference score
+- Click one to select it as your final choice
+- Use **"Give Pairwise Feedback"** to continue refining the model on the top picks
+- Click **"Regenerate"** to run another batch
+
+### Training the Model
+
+- The model auto-trains when transitioning between phases
+- You can also click **"Train Model"** at any time from the toolbar
+- Stats (preference count, model accuracy, training samples) are shown in the dashboard
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/preferences/grid` | Submit grid selection preferences |
+| POST | `/api/preferences/pairwise` | Submit a pairwise comparison |
+| POST | `/api/train` | Train/retrain the model |
+| POST | `/api/score` | Score a batch of COAs |
+| POST | `/api/suggest-pair` | Get the most uncertain pair (active learning) |
+| GET | `/api/stats` | Get preference and model statistics |
+| POST | `/api/reset` | Clear all preferences and reset the model |
+
+## Feature Extraction
+
+The model extracts ~68 structured features from each COA JSON:
+
+- **Tincture encoding**: One-hot encoding of field and charge tinctures (argent, or, gules, sable, azure, vert, purpure, murrey, sanguine, tenné)
+- **Pattern detection**: Whether the field uses a heraldic pattern (ermine, vair, etc.)
+- **Division encoding**: One-hot encoding of division types (per pale, per fess, etc.)
+- **Ordinary encoding**: One-hot encoding of ordinary types (fess, pale, chevron, etc.)
+- **Charge features**: Charge count, charge tincture encoding
+- **Complexity metric**: Combined measure of charges, ordinaries, divisions, and patterns
+
+## Data Storage
+
+Preferences are stored in `preference_data.json` in this directory. To start fresh, either delete the file or use the `/api/reset` endpoint.

--- a/preference/features.py
+++ b/preference/features.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import List
+
+TINCTURES = [
+    "argent",
+    "or",
+    "gules",
+    "sable",
+    "azure",
+    "vert",
+    "purpure",
+    "murrey",
+    "sanguine",
+    "tenné",
+]
+
+DIVISIONS = [
+    "perPale",
+    "perFess",
+    "perBend",
+    "perBendSinister",
+    "perCross",
+    "perSaltire",
+    "perChevron",
+    "perPile",
+    "gyronny",
+    "chevronny",
+]
+
+ORDINARIES = [
+    "fess",
+    "pale",
+    "bend",
+    "bendSinister",
+    "chief",
+    "base",
+    "chevron",
+    "cross",
+    "saltire",
+    "bordure",
+    "orle",
+    "mount",
+    "point",
+    "flaunches",
+    "gore",
+    "gyron",
+    "quarter",
+    "canton",
+    "pall",
+    "terrace",
+    "label",
+]
+
+
+def extract_base_tincture(t_str: str) -> str:
+    """Extract base tincture from a pattern string like 'ermine-argent-sable'."""
+    if not t_str:
+        return ""
+    if "-" not in t_str:
+        return t_str
+
+    parts = t_str.split("-")
+    for part in parts:
+        if part in TINCTURES:
+            return part
+
+    return parts[1] if len(parts) > 1 else t_str
+
+
+def _one_hot(value: str, options: List[str]) -> List[float]:
+    return [1.0 if value == option else 0.0 for option in options]
+
+
+def _zeros(count: int) -> List[float]:
+    return [0.0] * count
+
+
+def extract_features(coa: dict) -> List[float]:
+    """Extract a flat feature vector from a COA JSON object."""
+    coa = coa or {}
+    t1_raw = coa.get("t1", "")
+    t1 = extract_base_tincture(t1_raw) if isinstance(t1_raw, str) else ""
+    has_pattern = 1.0 if isinstance(t1_raw, str) and "-" in t1_raw else 0.0
+
+    division = coa.get("division") or {}
+    division_type = division.get("division", "") if isinstance(division, dict) else ""
+    has_division = 1.0 if division_type else 0.0
+    division_t = extract_base_tincture(division.get("t", "")) if has_division else ""
+
+    ordinaries = coa.get("ordinaries") or []
+    has_ordinary = 1.0 if ordinaries else 0.0
+    first_ordinary = ordinaries[0].get("ordinary", "") if ordinaries else ""
+
+    charges = coa.get("charges") or []
+    has_charge = 1.0 if charges else 0.0
+    num_charges = float(len(charges))
+    num_ordinaries = float(len(ordinaries))
+    first_charge_t = extract_base_tincture(charges[0].get("t", "")) if charges else ""
+
+    features: List[float] = []
+    features.extend(_one_hot(t1, TINCTURES))
+    features.append(has_pattern)
+
+    features.extend(_one_hot(division_t, TINCTURES) if has_division else _zeros(len(TINCTURES)))
+    features.extend(_one_hot(division_type, DIVISIONS) if has_division else _zeros(len(DIVISIONS)))
+    features.append(has_division)
+
+    features.extend(_one_hot(first_ordinary, ORDINARIES) if has_ordinary else _zeros(len(ORDINARIES)))
+    features.append(has_ordinary)
+
+    features.append(num_charges)
+    features.append(num_ordinaries)
+    features.append(has_charge)
+
+    features.extend(_one_hot(first_charge_t, TINCTURES) if has_charge else _zeros(len(TINCTURES)))
+
+    complexity = num_charges + num_ordinaries + has_division + has_pattern
+    features.append(float(complexity))
+
+    return features
+
+
+def get_feature_names() -> List[str]:
+    """Return a list of feature names aligned with extract_features."""
+    names: List[str] = []
+    names.extend([f"t1_{t}" for t in TINCTURES])
+    names.append("has_pattern")
+    names.extend([f"division_t_{t}" for t in TINCTURES])
+    names.extend([f"division_{d}" for d in DIVISIONS])
+    names.append("has_division")
+    names.extend([f"ordinary_{o}" for o in ORDINARIES])
+    names.append("has_ordinary")
+    names.append("num_charges")
+    names.append("num_ordinaries")
+    names.append("has_charge")
+    names.extend([f"charge_t_{t}" for t in TINCTURES])
+    names.append("complexity")
+    return names

--- a/preference/model.py
+++ b/preference/model.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from joblib import dump, load
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.preprocessing import StandardScaler
+
+from .features import extract_features, get_feature_names
+
+
+class PreferenceModel:
+    """Pairwise preference model based on a gradient boosted classifier."""
+
+    def __init__(self) -> None:
+        self.model: Optional[GradientBoostingClassifier] = None
+        self.scaler = StandardScaler()
+        self.is_trained = False
+        self.feature_names = get_feature_names()
+        self.reference_features = np.zeros(len(self.feature_names), dtype=float)
+
+    def _build_pairs(self, preferences: List[dict]) -> List[Tuple[dict, dict]]:
+        pairwise: List[Tuple[dict, dict]] = []
+        selected: List[dict] = []
+        rejected: List[dict] = []
+
+        for pref in preferences:
+            pref_type = pref.get("type")
+            if pref_type == "pairwise":
+                winner = pref.get("winner")
+                loser = pref.get("loser")
+                if winner and loser:
+                    pairwise.append((winner, loser))
+            elif pref_type == "grid":
+                coa = pref.get("coa")
+                if not coa:
+                    continue
+                if pref.get("selected"):
+                    selected.append(coa)
+                else:
+                    rejected.append(coa)
+
+        if selected and rejected:
+            for winner in selected:
+                for loser in rejected:
+                    pairwise.append((winner, loser))
+
+        return pairwise
+
+    def _compute_reference(self, preferences: List[dict]) -> np.ndarray:
+        all_features: List[List[float]] = []
+        for pref in preferences:
+            pref_type = pref.get("type")
+            if pref_type == "pairwise":
+                if pref.get("winner"):
+                    all_features.append(extract_features(pref["winner"]))
+                if pref.get("loser"):
+                    all_features.append(extract_features(pref["loser"]))
+            elif pref_type == "grid" and pref.get("coa"):
+                all_features.append(extract_features(pref["coa"]))
+
+        if not all_features:
+            return np.zeros(len(self.feature_names), dtype=float)
+
+        return np.mean(np.array(all_features, dtype=float), axis=0)
+
+    def fit(self, preferences: List[dict]) -> Dict[str, float]:
+        """Train the model from collected preferences."""
+        pairs = self._build_pairs(preferences)
+        if not pairs:
+            self.model = None
+            self.is_trained = False
+            return {"accuracy": 0.0, "n_samples": 0}
+
+        X: List[np.ndarray] = []
+        y: List[int] = []
+
+        for winner, loser in pairs:
+            winner_features = np.array(extract_features(winner), dtype=float)
+            loser_features = np.array(extract_features(loser), dtype=float)
+            diff = winner_features - loser_features
+
+            X.append(diff)
+            y.append(1)
+            X.append(-diff)
+            y.append(0)
+
+        X_array = np.array(X, dtype=float)
+        y_array = np.array(y, dtype=int)
+
+        self.scaler = StandardScaler()
+        X_scaled = self.scaler.fit_transform(X_array)
+
+        self.model = GradientBoostingClassifier(random_state=42)
+        self.model.fit(X_scaled, y_array)
+        self.is_trained = True
+
+        accuracy = float(self.model.score(X_scaled, y_array))
+        self.reference_features = self._compute_reference(preferences)
+
+        return {"accuracy": accuracy, "n_samples": int(len(y_array))}
+
+    def score(self, coa: dict) -> float:
+        """Return a preference score in [0, 1] for a single COA."""
+        if not self.model or not self.is_trained:
+            return 0.5
+
+        features = np.array(extract_features(coa), dtype=float)
+        diff = features - self.reference_features
+        X_scaled = self.scaler.transform([diff])
+        return float(self.model.predict_proba(X_scaled)[0][1])
+
+    def score_batch(self, coas: List[dict]) -> List[float]:
+        """Score a batch of COAs."""
+        return [self.score(coa) for coa in coas]
+
+    def get_uncertainty(self, coa1: dict, coa2: dict) -> float:
+        """Return uncertainty for the comparison between two COAs."""
+        if not self.model or not self.is_trained:
+            return 0.5
+
+        features1 = np.array(extract_features(coa1), dtype=float)
+        features2 = np.array(extract_features(coa2), dtype=float)
+        diff = features1 - features2
+        X_scaled = self.scaler.transform([diff])
+        proba = float(self.model.predict_proba(X_scaled)[0][1])
+        return float(1.0 - abs(proba - 0.5) * 2.0)
+
+    def save(self, path: str) -> None:
+        """Persist the model to disk."""
+        dump(
+            {
+                "model": self.model,
+                "scaler": self.scaler,
+                "is_trained": self.is_trained,
+                "feature_names": self.feature_names,
+                "reference_features": self.reference_features,
+            },
+            path,
+        )
+
+    def load(self, path: str) -> None:
+        """Load the model from disk."""
+        data = load(path)
+        self.model = data.get("model")
+        self.scaler = data.get("scaler", StandardScaler())
+        self.is_trained = data.get("is_trained", False)
+        self.feature_names = data.get("feature_names", get_feature_names())
+        self.reference_features = data.get(
+            "reference_features", np.zeros(len(self.feature_names), dtype=float)
+        )
+
+    def get_feature_importance(self) -> Dict[str, float]:
+        """Return feature importance weights."""
+        if not self.model or not self.is_trained:
+            return {}
+
+        importances = self.model.feature_importances_
+        return {name: float(value) for name, value in zip(self.feature_names, importances)}

--- a/preference/requirements.txt
+++ b/preference/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+scikit-learn
+numpy
+joblib
+pydantic

--- a/preference/server.py
+++ b/preference/server.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from .model import PreferenceModel
+
+DATA_PATH = Path(__file__).resolve().parent / "preference_data.json"
+STATIC_DIR = Path(__file__).resolve().parent.parent / "public"
+data_lock = Lock()
+
+app = FastAPI(title="Armoria Preference API")
+
+# CORS origins are configurable via the PREFERENCE_CORS_ORIGINS environment variable.
+# Provide a comma-separated list of allowed origins.
+# Default: http://localhost:5000
+_cors_origins_env = os.environ.get("PREFERENCE_CORS_ORIGINS", "http://localhost:5000")
+_cors_origins = [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class GridSelection(BaseModel):
+    coa: Dict[str, Any]
+    selected: bool
+
+
+class GridPreferenceRequest(BaseModel):
+    selections: List[GridSelection]
+
+
+class PairwisePreferenceRequest(BaseModel):
+    winner: Dict[str, Any]
+    loser: Dict[str, Any]
+
+
+class ScoreRequest(BaseModel):
+    coas: List[Dict[str, Any]]
+
+
+class SuggestPairRequest(BaseModel):
+    candidates: List[Dict[str, Any]]
+
+
+def load_preferences() -> List[Dict[str, Any]]:
+    if not DATA_PATH.exists():
+        return []
+    try:
+        with DATA_PATH.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data.get("preferences", [])
+            return []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def save_preferences(preferences: List[Dict[str, Any]]) -> None:
+    with data_lock:
+        with DATA_PATH.open("w", encoding="utf-8") as handle:
+            json.dump({"preferences": preferences}, handle, ensure_ascii=False, indent=2)
+
+
+preferences: List[Dict[str, Any]] = load_preferences()
+model = PreferenceModel()
+model_stats: Dict[str, Any] = {"accuracy": 0.0, "n_samples": 0}
+
+
+@app.post("/api/preferences/grid")
+def add_grid_preferences(payload: GridPreferenceRequest) -> Dict[str, Any]:
+    new_items = [
+        {"type": "grid", "coa": selection.coa, "selected": selection.selected}
+        for selection in payload.selections
+    ]
+    preferences.extend(new_items)
+    save_preferences(preferences)
+    return {"saved": len(new_items), "total": len(preferences)}
+
+
+@app.post("/api/preferences/pairwise")
+def add_pairwise_preferences(payload: PairwisePreferenceRequest) -> Dict[str, Any]:
+    preferences.append(
+        {"type": "pairwise", "winner": payload.winner, "loser": payload.loser}
+    )
+    save_preferences(preferences)
+    return {"saved": 1, "total": len(preferences)}
+
+
+@app.post("/api/train")
+def train_model() -> Dict[str, Any]:
+    global model_stats
+    model_stats = model.fit(preferences)
+    return {"trained": model.is_trained, **model_stats}
+
+
+@app.post("/api/score")
+def score_coas(payload: ScoreRequest) -> Dict[str, Any]:
+    scores = model.score_batch(payload.coas)
+    return {"scores": scores, "trained": model.is_trained}
+
+
+@app.post("/api/suggest-pair")
+def suggest_pair(payload: SuggestPairRequest) -> Dict[str, Any]:
+    from .features import extract_features
+    import numpy as np
+
+    candidates = payload.candidates
+    if len(candidates) < 2:
+        raise HTTPException(status_code=400, detail="At least two candidates required")
+
+    if model.is_trained:
+        # Pre-compute features for all candidates
+        features = [np.array(extract_features(c), dtype=float) for c in candidates]
+
+        # Minimum L1 feature distance to consider a pair "distinct enough"
+        MIN_DISTANCE = 3.0
+
+        best_pair = None
+        best_score = -1.0
+        best_uncertainty = 0.5
+
+        # Track the most distant pair as a fallback
+        max_distance_pair = None
+        max_distance = -1.0
+
+        for i in range(len(candidates)):
+            for j in range(i + 1, len(candidates)):
+                distance = float(np.sum(np.abs(features[i] - features[j])))
+
+                # Track most distant pair for fallback
+                if distance > max_distance:
+                    max_distance = distance
+                    max_distance_pair = (candidates[i], candidates[j])
+
+                # Skip pairs that are too similar
+                if distance < MIN_DISTANCE:
+                    continue
+
+                uncertainty = model.get_uncertainty(candidates[i], candidates[j])
+                # Combined score: uncertainty weighted by diversity
+                combined = uncertainty * (1.0 + distance)
+                if combined > best_score:
+                    best_score = combined
+                    best_uncertainty = uncertainty
+                    best_pair = (candidates[i], candidates[j])
+
+        # Fall back to most distant pair if no pair met the threshold
+        if best_pair is None:
+            if max_distance_pair is not None:
+                best_pair = max_distance_pair
+                best_uncertainty = model.get_uncertainty(
+                    max_distance_pair[0], max_distance_pair[1]
+                )
+            else:
+                best_pair = tuple(random.sample(candidates, 2))
+                best_uncertainty = 0.5
+
+        pair = list(best_pair)
+    else:
+        pair = random.sample(candidates, 2)
+        best_uncertainty = 0.5
+
+    return {
+        "pair": pair,
+        "uncertainty": best_uncertainty,
+        "trained": model.is_trained,
+    }
+
+
+@app.get("/api/stats")
+def get_stats() -> Dict[str, Any]:
+    grid_count = sum(1 for pref in preferences if pref.get("type") == "grid")
+    pairwise_count = sum(1 for pref in preferences if pref.get("type") == "pairwise")
+    selected_count = sum(
+        1
+        for pref in preferences
+        if pref.get("type") == "grid" and pref.get("selected")
+    )
+
+    return {
+        "total_preferences": len(preferences),
+        "grid_preferences": grid_count,
+        "pairwise_preferences": pairwise_count,
+        "grid_selected": selected_count,
+        "model_trained": model.is_trained,
+        "model_accuracy": model_stats.get("accuracy", 0.0),
+        "training_samples": model_stats.get("n_samples", 0),
+    }
+
+
+@app.post("/api/reset")
+def reset_preferences() -> Dict[str, Any]:
+    global model, model_stats
+    preferences.clear()
+    save_preferences(preferences)
+    model = PreferenceModel()
+    model_stats = {"accuracy": 0.0, "n_samples": 0}
+    return {"status": "reset", "total": len(preferences)}
+
+
+@app.get("/api/favorites")
+def get_favorites() -> Dict[str, Any]:
+    """Return COAs the user liked, grouped by source."""
+    grid_selections: List[Dict[str, Any]] = []
+    pairwise_winners: List[Dict[str, Any]] = []
+
+    for idx, pref in enumerate(preferences):
+        pref_type = pref.get("type")
+        if pref_type == "grid" and pref.get("selected"):
+            grid_selections.append({"index": idx, "coa": pref["coa"]})
+        elif pref_type == "pairwise":
+            winner = pref.get("winner")
+            if winner:
+                pairwise_winners.append({"index": idx, "coa": winner})
+
+    return {
+        "grid_selections": grid_selections,
+        "pairwise_winners": pairwise_winners,
+        "total": len(grid_selections) + len(pairwise_winners),
+    }
+
+
+# Mount static files AFTER API routes so /api/* takes priority.
+# This allows the FastAPI server to serve both the API and the Armoria
+# frontend from the same origin, eliminating cross-origin issues.
+if STATIC_DIR.is_dir():
+    app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="static")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    host = os.environ.get("PREFERENCE_HOST", "0.0.0.0")
+    port = int(os.environ.get("PREFERENCE_PORT", "8080"))
+    uvicorn.run("preference.server:app", host=host, port=port, reload=True)

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // @ts-check
   import {charges, shields} from "data/dataModel";
-  import {background, fonts, history, isTextReady, matrices, matrix, message, shield, size, state, uploaded} from "data/stores";
+  import {background, fonts, history, isTextReady, matrices, matrix, message, shield, size, state, uploaded, preferenceMode} from "data/stores";
   import {registerCharge} from "data/charges";
   import "scripts/i18n";
   import {rw} from "scripts/utils";
@@ -19,6 +19,7 @@
   import UploadVector from "./navigation/UploadVector.svelte";
   import Viewer from "./navigation/Viewer.svelte";
   import Navbar from "./navigation/header/Navbar.svelte";
+  import PreferenceMode from "./preference/PreferenceMode.svelte";
 
   let quantity: number;
   let width: number;
@@ -66,6 +67,14 @@
 
     // on coa edit or view mode
     if ($state.edit || $state.view) $state.c = $matrices[matrix][$state.i];
+  }
+
+  function togglePreferenceMode() {
+    $preferenceMode = !$preferenceMode;
+    if ($preferenceMode) {
+      $state.edit = 0;
+      $state.view = 0;
+    }
   }
 
   function loadFonts() {
@@ -151,9 +160,14 @@
   <div style="background-color: {$background}">
     <header>
       <Navbar />
+      <button class="pref-toggle" on:click={togglePreferenceMode}>
+        {$preferenceMode ? "Exit Preference Mode" : "Preference Mode"}
+      </button>
     </header>
 
-    {#if $state.edit}<Editor historyId={$state.c} {seed} />
+    {#if $preferenceMode}
+      <PreferenceMode />
+    {:else if $state.edit}<Editor historyId={$state.c} {seed} />
     {:else}<Gallery {gallery} {width} {height} />{/if}
 
     {#if $state.about}<About />{/if}
@@ -174,5 +188,30 @@
     height: 100%;
     width: 100%;
     background-image: url(../background.svg);
+  }
+
+  header {
+    position: relative;
+  }
+
+  .pref-toggle {
+    position: absolute;
+    right: 12px;
+    top: 10px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    border: 1px solid #444;
+    background: #222;
+    color: #f1f1f1;
+    font-size: 0.9em;
+    cursor: pointer;
+  }
+
+  .pref-toggle:hover {
+    background: #333;
+  }
+
+  .pref-toggle:active {
+    transform: translateY(1px);
   }
 </style>

--- a/src/components/preference/Favorites.svelte
+++ b/src/components/preference/Favorites.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  // @ts-check
+  import {onMount} from "svelte";
+  import {PREFERENCE_API_URL} from "config/preference";
+  import COA from "../object/COA.svelte";
+  import type {Coa} from "types/coa";
+
+  type FavoriteEntry = {index: number; coa: Coa};
+
+  const COA_SIZE = 140;
+
+  let gridSelections: FavoriteEntry[] = [];
+  let pairwiseWinners: FavoriteEntry[] = [];
+  let loading = true;
+
+  async function fetchFavorites() {
+    loading = true;
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/favorites`);
+      if (response.ok) {
+        const data = await response.json();
+        gridSelections = data.grid_selections || [];
+        pairwiseWinners = data.pairwise_winners || [];
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    loading = false;
+  }
+
+  function copyCoa(coa: Coa) {
+    const json = JSON.stringify(coa, null, 2);
+    navigator.clipboard.writeText(json).catch(console.error);
+  }
+
+  onMount(fetchFavorites);
+</script>
+
+<main class="favorites">
+  <header class="header">
+    <div>
+      <h2>Favorites</h2>
+      <p>Review the designs you liked. Click any coat of arms to copy its JSON.</p>
+    </div>
+    <div class="actions">
+      <button class="secondary" on:click={fetchFavorites} disabled={loading}>
+        {loading ? "Loading..." : "Refresh"}
+      </button>
+    </div>
+  </header>
+
+  {#if loading}
+    <p class="empty">Loading favorites...</p>
+  {:else if gridSelections.length === 0 && pairwiseWinners.length === 0}
+    <p class="empty">No favorites yet. Select some designs in the Grid Selection or Pairwise phases.</p>
+  {:else}
+    {#if gridSelections.length > 0}
+      <section class="section">
+        <h3>Grid Selections <span class="count">({gridSelections.length})</span></h3>
+        <p class="description">Designs you selected as favorites in the grid rounds.</p>
+        <div class="grid">
+          {#each gridSelections as entry}
+            <button class="card" on:click={() => copyCoa(entry.coa)} title="Click to copy COA JSON">
+              {#key entry.coa}
+                <COA coa={entry.coa} i={`fav-grid-${entry.index}`} width={COA_SIZE} height={COA_SIZE} />
+              {/key}
+            </button>
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    {#if pairwiseWinners.length > 0}
+      <section class="section">
+        <h3>Pairwise Winners <span class="count">({pairwiseWinners.length})</span></h3>
+        <p class="description">Designs you chose as the preferred option in head-to-head comparisons.</p>
+        <div class="grid">
+          {#each pairwiseWinners as entry}
+            <button class="card" on:click={() => copyCoa(entry.coa)} title="Click to copy COA JSON">
+              {#key entry.coa}
+                <COA coa={entry.coa} i={`fav-pair-${entry.index}`} width={COA_SIZE} height={COA_SIZE} />
+              {/key}
+            </button>
+          {/each}
+        </div>
+      </section>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  .favorites {
+    padding: 20px;
+    color: #f1f1f1;
+  }
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .header h2 {
+    margin: 0;
+    font-size: 1.2em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .header p {
+    margin: 4px 0 0;
+    color: #b8b8b8;
+    font-size: 0.95em;
+  }
+
+  .section {
+    margin-bottom: 28px;
+  }
+
+  .section h3 {
+    margin: 0 0 4px;
+    font-size: 1.05em;
+  }
+
+  .count {
+    color: #b8b8b8;
+    font-weight: normal;
+    font-size: 0.9em;
+  }
+
+  .description {
+    margin: 0 0 12px;
+    color: #b8b8b8;
+    font-size: 0.9em;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background: #00000040;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: #4d4d4d;
+    transform: translateY(-2px);
+  }
+
+  .card:active {
+    border-color: #3ddc84;
+  }
+
+  .empty {
+    color: #b8b8b8;
+  }
+
+  .actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  button.secondary {
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 8px 12px;
+    background: transparent;
+    color: #dcdcdc;
+    cursor: pointer;
+    font-size: 0.9em;
+  }
+
+  button.secondary:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/src/components/preference/GridSelection.svelte
+++ b/src/components/preference/GridSelection.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  // @ts-check
+  import {createEventDispatcher, onMount} from "svelte";
+  import {generate} from "scripts/generator";
+  import {PREFERENCE_API_URL} from "config/preference";
+  import {shield} from "data/stores";
+  import {shields} from "data/dataModel";
+  import {rw} from "scripts/utils";
+  import COA from "../object/COA.svelte";
+  import type {Coa} from "types/coa";
+
+  const dispatch = createEventDispatcher();
+  const GRID_SIZE = 20;
+  const COA_SIZE = 140;
+
+  let round = 1;
+  let coas: Coa[] = [];
+  let selections: boolean[] = [];
+  let submitting = false;
+
+  /** Generate a batch of independent COAs using crypto-random seeds
+   *  in the 0-999999999 range matching the generator's expected seed space.
+   *  Save and restore Math.random so the normal gallery is unaffected.
+   */
+  function buildBatch() {
+    const savedRandom = Math.random;
+    const seeds = new Uint32Array(GRID_SIZE);
+    crypto.getRandomValues(seeds);
+
+    $shield = rw(shields[rw(shields.types)]);
+
+    coas = Array.from(seeds, seed => generate(seed % 1000000000));
+    Math.random = savedRandom;
+    selections = Array(coas.length).fill(false);
+  }
+
+  $: selectedCount = selections.filter(Boolean).length;
+
+  function toggleSelection(index: number) {
+    selections[index] = !selections[index];
+    selections = selections.slice();
+  }
+
+  async function submitRound() {
+    if (submitting) return;
+    submitting = true;
+    const payload = {
+      selections: coas.map((coa, index) => ({
+        coa,
+        selected: selections[index]
+      }))
+    };
+
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/preferences/grid`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) throw new Error("Failed to submit selections");
+    } catch (error) {
+      console.error(error);
+    }
+
+    round += 1;
+    buildBatch();
+    submitting = false;
+    dispatch("update");
+  }
+
+  function finishPhase() {
+    dispatch("finish");
+  }
+
+  onMount(buildBatch);
+</script>
+
+<main class="grid-selection">
+  <header class="header">
+    <div>
+      <h2>Grid Selection</h2>
+      <p>Round {round} • Selected {selectedCount}/{coas.length}</p>
+    </div>
+    <div class="actions">
+      <button class="primary" on:click={submitRound} disabled={submitting}>
+        {submitting ? "Submitting..." : "Submit & Next Round"}
+      </button>
+      <button class="secondary" on:click={finishPhase}>Finish Phase 1</button>
+    </div>
+  </header>
+
+  <div class="grid">
+    {#each coas as coa, i}
+      <div class="item" class:selected={selections[i]} on:click={() => toggleSelection(i)}>
+        {#key coa}
+          <COA {coa} i={`grid-${i}`} width={COA_SIZE} height={COA_SIZE} />
+        {/key}
+      </div>
+    {/each}
+  </div>
+</main>
+
+<style>
+  .grid-selection {
+    padding: 20px;
+    color: #f1f1f1;
+  }
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .header h2 {
+    margin: 0;
+    font-size: 1.2em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .header p {
+    margin: 4px 0 0;
+    color: #b8b8b8;
+    font-size: 0.95em;
+  }
+
+  .actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+  }
+
+  .item {
+    padding: 8px;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background: #00000040;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .item:hover {
+    border-color: #4d4d4d;
+    transform: translateY(-2px);
+  }
+
+  .item.selected {
+    border-color: #3ddc84;
+    box-shadow: 0 0 0 1px #3ddc84;
+  }
+
+  button {
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.9em;
+  }
+
+  button.primary {
+    background: #2b2b2b;
+    color: #f1f1f1;
+  }
+
+  button.secondary {
+    background: transparent;
+    color: #dcdcdc;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/src/components/preference/GuidedGeneration.svelte
+++ b/src/components/preference/GuidedGeneration.svelte
@@ -1,0 +1,343 @@
+<script lang="ts">
+  // @ts-check
+  import {createEventDispatcher} from "svelte";
+  import {generate} from "scripts/generator";
+  import {PREFERENCE_API_URL} from "config/preference";
+  import {shield} from "data/stores";
+  import {shields} from "data/dataModel";
+  import {rw} from "scripts/utils";
+  import COA from "../object/COA.svelte";
+  import type {Coa} from "types/coa";
+
+  type ScoredCoa = {coa: Coa; score: number};
+
+  const dispatch = createEventDispatcher();
+  const BATCH_SIZE = 200;
+  const TOP_K = 20;
+  const COA_SIZE = 140;
+  const FEEDBACK_SIZE = 220;
+
+  let scored: ScoredCoa[] = [];
+  let loading = false;
+  let selectedIndex: number | null = null;
+  let feedbackActive = false;
+  let feedbackPair: ScoredCoa[] = [];
+  let feedbackSubmitting = false;
+
+  async function generateBatch() {
+    if (loading) return;
+    loading = true;
+    selectedIndex = null;
+    const savedRandom = Math.random;
+    const seeds = new Uint32Array(BATCH_SIZE);
+    crypto.getRandomValues(seeds);
+
+    $shield = rw(shields[rw(shields.types)]);
+
+    const candidates = Array.from(seeds, seed => generate(seed % 1000000000));
+    Math.random = savedRandom;
+
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/score`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({coas: candidates})
+      });
+
+      let scores: number[] = [];
+      if (response.ok) {
+        const data = await response.json();
+        if (Array.isArray(data.scores)) scores = data.scores;
+      }
+
+      const scoredAll = candidates.map((coa, index) => ({
+        coa,
+        score: typeof scores[index] === "number" ? scores[index] : 0.5
+      }));
+      scoredAll.sort((a, b) => b.score - a.score);
+      scored = scoredAll.slice(0, TOP_K);
+    } catch (error) {
+      console.error(error);
+      scored = candidates.slice(0, TOP_K).map(coa => ({coa, score: 0.5}));
+    }
+
+    loading = false;
+    if (feedbackActive) {
+      pickFeedbackPair();
+    }
+  }
+
+  function selectFinal(index: number) {
+    selectedIndex = index;
+  }
+
+  function toggleFeedback() {
+    feedbackActive = !feedbackActive;
+    if (feedbackActive) {
+      pickFeedbackPair();
+    }
+  }
+
+  function pickFeedbackPair() {
+    if (scored.length < 2) {
+      feedbackPair = [];
+      return;
+    }
+    const first = Math.floor(Math.random() * scored.length);
+    let second = Math.floor(Math.random() * scored.length);
+    while (second === first) {
+      second = Math.floor(Math.random() * scored.length);
+    }
+    feedbackPair = [scored[first], scored[second]];
+  }
+
+  async function chooseFeedback(index: number) {
+    if (feedbackSubmitting || feedbackPair.length < 2) return;
+    feedbackSubmitting = true;
+    const winner = feedbackPair[index].coa;
+    const loser = feedbackPair[index === 0 ? 1 : 0].coa;
+
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/preferences/pairwise`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({winner, loser})
+      });
+      if (!response.ok) throw new Error("Failed to submit feedback");
+      dispatch("update");
+    } catch (error) {
+      console.error(error);
+    }
+
+    feedbackSubmitting = false;
+    pickFeedbackPair();
+  }
+</script>
+
+<main class="guided">
+  <header class="header">
+    <div>
+      <h2>Guided Generation</h2>
+      <p>Generate a batch and review the model's top-ranked results.</p>
+    </div>
+    <div class="actions">
+      <button class="primary" on:click={generateBatch} disabled={loading}>
+        {loading ? "Scoring..." : scored.length ? "Regenerate" : "Generate"}
+      </button>
+      <button class="secondary" on:click={toggleFeedback} disabled={scored.length < 2}>
+        {feedbackActive ? "Hide Pairwise Feedback" : "Give Pairwise Feedback"}
+      </button>
+    </div>
+  </header>
+
+  {#if scored.length}
+    <div class="grid">
+      {#each scored as item, i}
+        <button class="card" class:selected={selectedIndex === i} on:click={() => selectFinal(i)}>
+          {#key item.coa}
+            <COA coa={item.coa} i={`guided-${i}`} width={COA_SIZE} height={COA_SIZE} />
+          {/key}
+          <div class="score">Score: {item.score.toFixed(3)}</div>
+          {#if selectedIndex === i}
+            <div class="chosen-label">Selected</div>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {:else}
+    <p class="empty">Click "Generate" to score a new batch of coats of arms.</p>
+  {/if}
+
+  {#if feedbackActive}
+    <section class="feedback">
+      <div class="feedback-header">
+        <div>
+          <h3>Pairwise Feedback</h3>
+          <p>Keep refining the model by choosing between two top picks.</p>
+        </div>
+        <button class="secondary" on:click={pickFeedbackPair} disabled={scored.length < 2 || feedbackSubmitting}>
+          New Pair
+        </button>
+      </div>
+
+      {#if feedbackPair.length === 2}
+        <div class="feedback-pair">
+          {#each feedbackPair as item, index}
+            <button class="feedback-choice" on:click={() => chooseFeedback(index)} disabled={feedbackSubmitting}>
+              {#key item.coa}
+                <COA coa={item.coa} i={`feedback-${index}`} width={FEEDBACK_SIZE} height={FEEDBACK_SIZE} />
+              {/key}
+              <span class="label">{index === 0 ? "Option A" : "Option B"}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
+</main>
+
+<style>
+  .guided {
+    padding: 20px;
+    color: #f1f1f1;
+  }
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .header h2 {
+    margin: 0;
+    font-size: 1.2em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .header p {
+    margin: 4px 0 0;
+    color: #b8b8b8;
+    font-size: 0.95em;
+  }
+
+  .actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: center;
+    padding: 8px;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background: #00000040;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: #4d4d4d;
+    transform: translateY(-2px);
+  }
+
+  .card.selected {
+    border-color: #3ddc84;
+    box-shadow: 0 0 0 1px #3ddc84;
+  }
+
+  .score {
+    color: #b8b8b8;
+    font-size: 0.85em;
+  }
+
+  .chosen-label {
+    color: #3ddc84;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  .empty {
+    color: #b8b8b8;
+  }
+
+  .feedback {
+    margin-top: 24px;
+    padding: 16px;
+    border-radius: 10px;
+    border: 1px solid #2d2d2d;
+    background: #00000045;
+  }
+
+  .feedback-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .feedback-header h3 {
+    margin: 0;
+    font-size: 1.05em;
+  }
+
+  .feedback-header p {
+    margin: 4px 0 0;
+    color: #b8b8b8;
+    font-size: 0.9em;
+  }
+
+  .feedback-pair {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+  }
+
+  .feedback-choice {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    padding: 10px;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background: #00000050;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .feedback-choice:hover {
+    border-color: #5a5a5a;
+    transform: translateY(-2px);
+  }
+
+  .feedback-choice:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .label {
+    color: #c9c9c9;
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  button.primary,
+  button.secondary {
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.9em;
+  }
+
+  button.primary {
+    background: #2b2b2b;
+    color: #f1f1f1;
+  }
+
+  button.secondary {
+    background: transparent;
+    color: #dcdcdc;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/src/components/preference/PairwiseComparison.svelte
+++ b/src/components/preference/PairwiseComparison.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  // @ts-check
+  import {createEventDispatcher, onMount} from "svelte";
+  import {generate} from "scripts/generator";
+  import {PREFERENCE_API_URL} from "config/preference";
+  import {shield} from "data/stores";
+  import {shields} from "data/dataModel";
+  import {rw} from "scripts/utils";
+  import COA from "../object/COA.svelte";
+  import type {Coa} from "types/coa";
+
+  export let modelReady = false;
+
+  const dispatch = createEventDispatcher();
+  const CANDIDATE_POOL = 40;
+  const COA_SIZE = 260;
+
+  let pair: Coa[] = [];
+  let comparisons = 0;
+  let loading = false;
+
+  /** Generate candidates with independent crypto-random seeds in 0-999999999. */
+  function buildCandidates() {
+    const savedRandom = Math.random;
+    const seeds = new Uint32Array(CANDIDATE_POOL);
+    crypto.getRandomValues(seeds);
+
+    $shield = rw(shields[rw(shields.types)]);
+
+    const result = Array.from(seeds, seed => generate(seed % 1000000000));
+    Math.random = savedRandom;
+    return result;
+  }
+
+  function pickRandomPair(candidates: Coa[]) {
+    if (candidates.length < 2) return [];
+    const arr = new Uint32Array(2);
+    crypto.getRandomValues(arr);
+    const first = arr[0] % candidates.length;
+    let second = arr[1] % candidates.length;
+    while (second === first) {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      second = buf[0] % candidates.length;
+    }
+    return [candidates[first], candidates[second]];
+  }
+
+  async function loadPair() {
+    loading = true;
+    const candidates = buildCandidates();
+
+    if (modelReady) {
+      try {
+        const response = await fetch(`${PREFERENCE_API_URL}/api/suggest-pair`, {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({candidates})
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (Array.isArray(data.pair) && data.pair.length === 2) {
+            pair = data.pair;
+            loading = false;
+            return;
+          }
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    pair = pickRandomPair(candidates);
+    loading = false;
+  }
+
+  async function choose(index: number) {
+    if (loading || pair.length < 2) return;
+    loading = true;
+    const winner = pair[index];
+    const loser = pair[index === 0 ? 1 : 0];
+
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/preferences/pairwise`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({winner, loser})
+      });
+      if (!response.ok) throw new Error("Failed to submit pairwise preference");
+      dispatch("update");
+    } catch (error) {
+      console.error(error);
+    }
+
+    comparisons += 1;
+    await loadPair();
+  }
+
+  function finishPhase() {
+    dispatch("finish");
+  }
+
+  onMount(loadPair);
+</script>
+
+<main class="pairwise">
+  <header class="header">
+    <div>
+      <h2>Pairwise Comparison</h2>
+      <p>Comparisons: {comparisons} {modelReady ? "• Active learning" : "• Random pairs"}</p>
+    </div>
+    <div class="actions">
+      <button class="secondary" on:click={loadPair} disabled={loading}>New Pair</button>
+      <button class="secondary" on:click={finishPhase}>Finish Phase 2</button>
+    </div>
+  </header>
+
+  {#if pair.length === 2}
+    <div class="pair">
+      {#each pair as coa, index}
+        <button class="choice" on:click={() => choose(index)} disabled={loading}>
+          {#key coa}
+            <COA {coa} i={`pair-${index}`} width={COA_SIZE} height={COA_SIZE} />
+          {/key}
+          <span class="label">{index === 0 ? "Option A" : "Option B"}</span>
+        </button>
+      {/each}
+    </div>
+  {:else}
+    <p class="loading">Generating a new pair...</p>
+  {/if}
+</main>
+
+<style>
+  .pairwise {
+    padding: 20px;
+    color: #f1f1f1;
+  }
+
+  .header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .header h2 {
+    margin: 0;
+    font-size: 1.2em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .header p {
+    margin: 4px 0 0;
+    color: #b8b8b8;
+    font-size: 0.95em;
+  }
+
+  .actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+
+  .pair {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+  }
+
+  .choice {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+    padding: 12px;
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background: #00000045;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .choice:hover {
+    border-color: #5a5a5a;
+    transform: translateY(-2px);
+  }
+
+  .choice:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .label {
+    color: #c9c9c9;
+    font-size: 0.9em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .loading {
+    color: #c9c9c9;
+  }
+
+  button.secondary {
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 8px 12px;
+    background: transparent;
+    color: #dcdcdc;
+    cursor: pointer;
+  }
+
+  button.secondary:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/src/components/preference/PreferenceMode.svelte
+++ b/src/components/preference/PreferenceMode.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+  // @ts-check
+  import {onMount} from "svelte";
+  import {preferenceMode} from "data/stores";
+  import {PREFERENCE_API_URL} from "config/preference";
+  import GridSelection from "./GridSelection.svelte";
+  import PairwiseComparison from "./PairwiseComparison.svelte";
+  import GuidedGeneration from "./GuidedGeneration.svelte";
+  import Favorites from "./Favorites.svelte";
+
+  type Stats = {
+    total_preferences: number;
+    grid_preferences: number;
+    pairwise_preferences: number;
+    grid_selected: number;
+    model_trained: boolean;
+    model_accuracy: number;
+    training_samples: number;
+  };
+
+  const phases = ["Grid Selection", "Pairwise", "Guided", "Favorites"];
+
+  let phase = 0;
+  let training = false;
+  let stats: Stats = {
+    total_preferences: 0,
+    grid_preferences: 0,
+    pairwise_preferences: 0,
+    grid_selected: 0,
+    model_trained: false,
+    model_accuracy: 0,
+    training_samples: 0
+  };
+
+  $: accuracyLabel = stats.model_trained ? `${(stats.model_accuracy * 100).toFixed(1)}%` : "—";
+
+  async function fetchStats() {
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/stats`);
+      if (response.ok) {
+        stats = await response.json();
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function trainModel() {
+    if (training) return;
+    training = true;
+    try {
+      const response = await fetch(`${PREFERENCE_API_URL}/api/train`, {method: "POST"});
+      if (response.ok) {
+        const data = await response.json();
+        stats = {
+          ...stats,
+          model_trained: data.trained ?? stats.model_trained,
+          model_accuracy: data.accuracy ?? stats.model_accuracy,
+          training_samples: data.n_samples ?? stats.training_samples
+        };
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    training = false;
+    await fetchStats();
+  }
+
+  function setPhase(index: number) {
+    phase = index;
+  }
+
+  function finishPhase1() {
+    phase = 1;
+    trainModel();
+  }
+
+  function finishPhase2() {
+    phase = 2;
+    trainModel();
+  }
+
+  function exitPreference() {
+    $preferenceMode = false;
+  }
+
+  onMount(fetchStats);
+</script>
+
+<div class="preference-mode">
+  <div class="toolbar">
+    <button class="back" on:click={exitPreference}>Back to Gallery</button>
+    <div class="tabs">
+      {#each phases as label, index}
+        <button class="tab" class:active={phase === index} on:click={() => setPhase(index)}>
+          {label}
+        </button>
+      {/each}
+    </div>
+    <button class="train" on:click={trainModel} disabled={training}>
+      {training ? "Training..." : "Train Model"}
+    </button>
+  </div>
+
+  <div class="stats">
+    <div class="stat">
+      <span class="label">Preferences</span>
+      <span class="value">{stats.total_preferences}</span>
+    </div>
+    <div class="stat">
+      <span class="label">Grid</span>
+      <span class="value">{stats.grid_preferences} ({stats.grid_selected} selected)</span>
+    </div>
+    <div class="stat">
+      <span class="label">Pairwise</span>
+      <span class="value">{stats.pairwise_preferences}</span>
+    </div>
+    <div class="stat">
+      <span class="label">Model</span>
+      <span class="value">{stats.model_trained ? "Trained" : "Untrained"}</span>
+    </div>
+    <div class="stat">
+      <span class="label">Accuracy</span>
+      <span class="value">{accuracyLabel}</span>
+    </div>
+    <div class="stat">
+      <span class="label">Samples</span>
+      <span class="value">{stats.training_samples}</span>
+    </div>
+  </div>
+
+  <section class="content">
+    {#if phase === 0}
+      <GridSelection on:update={fetchStats} on:finish={finishPhase1} />
+    {:else if phase === 1}
+      <PairwiseComparison modelReady={stats.model_trained} on:update={fetchStats} on:finish={finishPhase2} />
+    {:else if phase === 2}
+      <GuidedGeneration on:update={fetchStats} />
+    {:else}
+      <Favorites />
+    {/if}
+  </section>
+</div>
+
+<style>
+  .preference-mode {
+    color: #f1f1f1;
+    min-height: calc(100vh - 60px);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-bottom: 20px;
+  }
+
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px 0;
+  }
+
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .tab {
+    border-radius: 999px;
+    border: 1px solid #3a3a3a;
+    padding: 6px 14px;
+    background: transparent;
+    color: #dcdcdc;
+    cursor: pointer;
+  }
+
+  .tab.active {
+    background: #2b2b2b;
+    border-color: #4d4d4d;
+    color: #fff;
+  }
+
+  .back,
+  .train {
+    border-radius: 4px;
+    border: 1px solid #3a3a3a;
+    padding: 8px 12px;
+    background: #222;
+    color: #f1f1f1;
+    cursor: pointer;
+  }
+
+  .train:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 12px;
+    padding: 0 20px;
+  }
+
+  .stat {
+    background: #00000040;
+    border: 1px solid #2d2d2d;
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .label {
+    color: #b8b8b8;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .value {
+    font-size: 1.05em;
+  }
+
+  .content {
+    flex: 1;
+  }
+</style>

--- a/src/config/preference.ts
+++ b/src/config/preference.ts
@@ -1,0 +1,28 @@
+/**
+ * Preference system configuration.
+ *
+ * The API URL is resolved in this order:
+ * 1. Build-time injection via process.env.PREFERENCE_API_URL (Rollup replace plugin)
+ * 2. Empty string (same-origin) — the FastAPI server serves both the API and
+ *    the static frontend, so no cross-origin requests are needed.
+ *
+ * To override at build time, set the PREFERENCE_API_URL environment variable
+ * before running `npm run dev` or `npm run build`.
+ */
+
+declare const process: {env: Record<string, string | undefined>};
+
+function resolveApiUrl(): string {
+  try {
+    const envValue =
+      typeof process !== "undefined" && process.env && process.env.PREFERENCE_API_URL;
+    if (envValue) return envValue;
+  } catch {
+    // process may not exist in browser context
+  }
+
+  // Same-origin: API is served from the same host/port as the frontend
+  return "";
+}
+
+export const PREFERENCE_API_URL: string = resolveApiUrl();

--- a/src/data/stores.ts
+++ b/src/data/stores.ts
@@ -59,6 +59,7 @@ export const state = writable({
 });
 
 export const iconedNav = writable(false);
+export const preferenceMode = writable(false);
 
 const createMessageStore = () => {
   const {subscribe, set} = writable(null);


### PR DESCRIPTION
## Summary

Adds a complete human-preference learning system to Armoria that helps users discover their ideal coat of arms through a three-phase workflow: grid selection, pairwise comparison with active learning, and model-guided generation via rejection sampling.

## Architecture

- **Python backend** (`preference/`): FastAPI server with preference collection, reward model training, scoring, and active learning
- **Svelte frontend** (`src/components/preference/`): Four-tab UI integrated into the existing Armoria app
- **Hybrid model**: Gradient Boosted Classifier trained on 68-dimensional structured COA features using Bradley-Terry pairwise preference learning

## Components

### Backend (`preference/`)
| File | Purpose |
|------|--------|
| `features.py` | COA feature extraction (~68 features: tinctures, divisions, ordinaries, charges, complexity) |
| `model.py` | Pairwise preference model (GBC on feature differences with StandardScaler) |
| `server.py` | FastAPI server with endpoints for preferences, training, scoring, active learning, favorites, and static file serving |
| `requirements.txt` | Python dependencies |
| `README.md` | Complete setup and usage documentation |

### Frontend (`src/components/preference/`)
| File | Purpose |
|------|--------|
| `PreferenceMode.svelte` | Main container with phase tabs, stats dashboard, and train button |
| `GridSelection.svelte` | Phase 1: Grid of 20 COAs with click-to-select and round progression |
| `PairwiseComparison.svelte` | Phase 2: Side-by-side comparisons with active learning (uncertainty × diversity) |
| `GuidedGeneration.svelte` | Phase 3: Rejection sampling — generates 200, scores, shows top 20 |
| `Favorites.svelte` | Review tab: displays all liked COAs from grid selections and pairwise winners |

### Configuration
| File | Purpose |
|------|--------|
| `src/config/preference.ts` | Configurable API URL (build-time env var or same-origin default) |
| `src/data/stores.ts` | Added `preferenceMode` writable store |
| `src/components/App.svelte` | Integrated preference mode toggle and rendering |

## Three-Phase Workflow

1. **Grid Selection**: Browse 20 randomly generated COAs per round, click favorites, submit to collect broad preference signal
2. **Pairwise Comparison**: Choose between pairs selected via active learning (uncertainty × feature distance with minimum distance threshold for visual distinctness)
3. **Guided Generation**: Model scores 200 random candidates, surfaces top 20 via rejection sampling
4. **Favorites**: Review all liked designs grouped by source (grid selections vs pairwise winners)

## Key Design Decisions

- **Same-origin serving**: FastAPI serves both the API (`/api/*`) and static frontend files, eliminating CORS issues
- **`{#key coa}` directive**: Forces Svelte to re-create COA components on data change, matching Gallery.svelte's rendering pattern
- **Crypto-random seeds**: `crypto.getRandomValues` generates independent seeds (0–999999999) for each COA, with `Math.random` saved/restored around batch generation
- **Shield randomization**: Each batch randomizes the shield shape via `$shield = rw(shields[rw(shields.types)])`, matching normal Armoria reroll behavior
- **Diversity-aware active learning**: `suggest-pair` uses combined `uncertainty × (1 + feature_distance)` with a minimum distance threshold of 3.0, falling back to the most distant pair
- **Configurable**: CORS origins, server host/port, and API URL are all configurable via environment variables

---

**Created by Maestro on behalf of Andrei Alexandru**

[View Session](https://dev.igent.ai/thread/7f8628ce-ecce-4be2-876c-14b28615325d)